### PR TITLE
Start and last image controls

### DIFF
--- a/frontend-ui/src/app/components/ItemViewer.tsx
+++ b/frontend-ui/src/app/components/ItemViewer.tsx
@@ -59,6 +59,8 @@ export default function ItemViewer() {
 
   const scrollPrev = () => emblaApi && emblaApi.scrollPrev();
   const scrollNext = () => emblaApi && emblaApi.scrollNext();
+  const scrollToFirst = () => emblaApi && emblaApi.scrollTo(0);
+  const scrollToLast = () => emblaApi && emblaApi.scrollTo(images.length - 1);
 
   React.useEffect(() => {
     async function fetchImages() {
@@ -104,8 +106,10 @@ export default function ItemViewer() {
           <ViewportCarousel emblaRef={emblaRef} images={images} onImageClick={(src) => setLightboxSrc(src)} />
 
           <ButtonContainer>
+            <Button onClick={scrollToFirst}>Start</Button>
             <Button onClick={scrollPrev}>Previous</Button>
             <Button onClick={scrollNext}>Next</Button>
+            <Button onClick={scrollToLast}>Last</Button>
           </ButtonContainer>
 
           <ProgressSlider


### PR DESCRIPTION
Issues Closed:
#4 

Changes:
- added a "start" button to navigate to the start image of the carousel
- added a "last" button to navigate to the last image of the carousel


Screenshot:
<img width="1448" height="1194" alt="image" src="https://github.com/user-attachments/assets/ce2af298-9521-49ef-992f-8c5c1838de15" />
Figure: New start and last buttons